### PR TITLE
Split MediaWikiServices hook handler

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -18,7 +18,7 @@
     "EchoGetBundleRules": "MediaWiki\\Extension\\AchievementBadges\\HookHandler\\Main::onEchoGetBundleRules",
     "GetBetaFeaturePreferences": "MediaWiki\\Extension\\AchievementBadges\\HookHandler\\Main::onGetBetaFeaturePreferences",
     "ContributionsToolLinks": "Main",
-    "MediaWikiServices": "Main",
+    "MediaWikiServices": "MediaWikiServices",
     "ResourceLoaderGetConfigVars": "Main",
     "APIAfterExecute": "AchievementRegister",
     "BeforeCreateAchievement": "AchievementRegister",
@@ -32,6 +32,9 @@
     "Main": {
       "class": "MediaWiki\\Extension\\AchievementBadges\\HookHandler\\Main",
       "services": ["MainConfig", "AchievementBadgesHookRunner"]
+    },
+    "MediaWikiServices": {
+      "class": "MediaWiki\\Extension\\AchievementBadges\\HookHandler\\MediaWikiServices"
     },
     "AchievementRegister": {
       "class": "MediaWiki\\Extension\\AchievementBadges\\HookHandler\\AchievementRegister",

--- a/includes/HookHandler/Main.php
+++ b/includes/HookHandler/Main.php
@@ -16,8 +16,7 @@ use User;
 
 class Main implements
 	\MediaWiki\ResourceLoader\Hook\ResourceLoaderGetConfigVarsHook,
-	\MediaWiki\Hook\ContributionsToolLinksHook,
-	\MediaWiki\Hook\MediaWikiServicesHook
+	\MediaWiki\Hook\ContributionsToolLinksHook
 	{
 
 	/** @var Config */
@@ -33,34 +32,6 @@ class Main implements
 	public function __construct( Config $config, HookRunner $hookRunner ) {
 		$this->config = $config;
 		$this->hookRunner = $hookRunner;
-	}
-
-	/**
-	 * Invoked via $wgExtensionFunctions.
-	 * @todo hide or disable echo-subscriptions-web-thank-you-edit option when replaced
-	 * @inheritDoc
-	 */
-	public function onMediaWikiServices( $services ) {
-		global $wgAchievementBadgesAchievements, $wgNotifyTypeAvailabilityByCategory,
-			$wgAchievementBadgesDisabledAchievements;
-
-		$this->hookRunner->onBeforeCreateAchievement( $wgAchievementBadgesAchievements );
-
-		foreach ( $wgAchievementBadgesDisabledAchievements as $key ) {
-			unset( $wgAchievementBadgesAchievements[ $key ] );
-		}
-
-		// Below code make Echo tests to fail
-		if ( defined( 'MW_PHPUNIT_TEST' ) ) {
-			return;
-		}
-
-		// Overwrite echo's milestone if configured.
-		$config = MediaWikiServices::getInstance()->getMainConfig();
-		if ( !$config->get( Constants::CONFIG_KEY_ENABLE_BETA_FEATURE ) &&
-			$config->get( Constants::CONFIG_KEY_REPLACE_ECHO_THANK_YOU_EDIT ) ) {
-				$wgNotifyTypeAvailabilityByCategory['thank-you-edit']['web'] = false;
-		}
 	}
 
 	/**

--- a/includes/HookHandler/MediaWikiServices.php
+++ b/includes/HookHandler/MediaWikiServices.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MediaWiki\Extension\AchievementBadges\HookHandler;
+
+use MediaWiki\Extension\AchievementBadges\Constants;
+
+class MediaWikiServices implements \MediaWiki\Hook\MediaWikiServicesHook {
+
+	/**
+	 * @todo hide or disable echo-subscriptions-web-thank-you-edit option when replaced
+	 * @inheritDoc
+	 */
+	public function onMediaWikiServices( $services ) {
+		global $wgAchievementBadgesAchievements, $wgNotifyTypeAvailabilityByCategory,
+			$wgAchievementBadgesDisabledAchievements;
+
+		$hookRunner = $services->get( 'AchievementBadgesHookRunner' );
+		$hookRunner->onBeforeCreateAchievement( $wgAchievementBadgesAchievements );
+
+		foreach ( $wgAchievementBadgesDisabledAchievements as $key ) {
+			unset( $wgAchievementBadgesAchievements[ $key ] );
+		}
+
+		// Below code make Echo tests to fail
+		if ( defined( 'MW_PHPUNIT_TEST' ) ) {
+			return;
+		}
+
+		// Overwrite echo's milestone if configured.
+		$config = $services->getMainConfig();
+		if ( !$config->get( Constants::CONFIG_KEY_ENABLE_BETA_FEATURE ) &&
+			$config->get( Constants::CONFIG_KEY_REPLACE_ECHO_THANK_YOU_EDIT ) ) {
+				$wgNotifyTypeAvailabilityByCategory['thank-you-edit']['web'] = false;
+		}
+	}
+}

--- a/includes/HookHandler/MediaWikiServices.php
+++ b/includes/HookHandler/MediaWikiServices.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\AchievementBadges\HookHandler;
 
 use MediaWiki\Extension\AchievementBadges\Constants;
+use MediaWiki\MediaWikiServices as MediaWikiMediaWikiServices;
 
 class MediaWikiServices implements \MediaWiki\Hook\MediaWikiServicesHook {
 
@@ -14,6 +15,7 @@ class MediaWikiServices implements \MediaWiki\Hook\MediaWikiServicesHook {
 		global $wgAchievementBadgesAchievements, $wgNotifyTypeAvailabilityByCategory,
 			$wgAchievementBadgesDisabledAchievements;
 
+		$services = MediaWikiMediaWikiServices::getInstance();
 		$hookRunner = $services->get( 'AchievementBadgesHookRunner' );
 		$hookRunner->onBeforeCreateAchievement( $wgAchievementBadgesAchievements );
 


### PR DESCRIPTION
The handler for the hook MediaWikiServices should not has a service dependency.

> UnexpectedValueException: The handler for the hook MediaWikiServices registered in /workspace/src/extensions/AchievementBadges/extension.json has a service dependency, but this hook does not allow it.