### PR TITLE
Remove username parameter from a message for anons

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,7 +25,7 @@
   "special-shareachievement-item-twitter": "Twitter",
   "special-shareachievement-tweet": "I just {{GENDER:$1|earned}} the $2 achievement at {{SITENAME}}! $3",
   "special-shareachievement-tweet-viewer": "$1 just {{GENDER:$1|earned}} the $2 achievement at {{SITENAME}}! $3",
-  "special-shareachievement-suggestion-sign-up": "[[Special:Createaccount|{{GENDER:$1|Sign}} up]] now to start getting achievements.\n\nHave an account? [[Special:Login|Sign in]]",
+  "special-shareachievement-suggestion-sign-up": "[[Special:Createaccount|Sign up]] now to start getting achievements.\n\nHave an account? [[Special:Login|Sign in]]",
   "special-shareachievement-suggestion-beta": "[[Special:Preferences#mw-prefsection-betafeatures|{{GENDER:$1|Start}} getting achievements now!]]",
   "achievementbadges-beta-feature-achievement-enable-message": "Achievement Badges",
   "achievementbadges-beta-feature-achievement-enable-description": "Earn given achievements to get badges.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -30,7 +30,7 @@
 	"special-shareachievement-item-twitter": "This is a label for a link for sharing.",
 	"special-shareachievement-tweet": "This is used to send a new tweet.\n* $1 - user's name\n* $2 - the name of the obtained achievement\n* $3 - URL to the achievement page",
 	"special-shareachievement-tweet-viewer": "This is used to send a new tweet that is obtained by other than the user who tweets.\n* $1 - user's name\n* $2 - the name of the obtained achievement\n* $3 - URL to the achievement page",
-	"special-shareachievement-suggestion-sign-up": "\n* $1 - user's name",
+	"special-shareachievement-suggestion-sign-up": "Shown to anonymous users.",
 	"special-shareachievement-suggestion-beta": "\n* $1 - user's name",
 	"achievementbadges-beta-feature-achievement-enable-message": "Used in [[Special:Preferences]].\n\nUsed as label for checkbox to enable the achievement system.\n\nThe description for this checkbox is {{msg-mw|achievementbadges-beta-feature-achievement-enable-description}}",
 	"achievementbadges-beta-feature-achievement-enable-description": "Used in [[Special:Preferences]].\n\nUsed as description for the checkbox to enable the achievement system.\n\nThe label for this checkbox is {{msg-mw|achievementbadges-beta-feature-achievement-enable-message}}.",

--- a/includes/Special/SpecialShareAchievement.php
+++ b/includes/Special/SpecialShareAchievement.php
@@ -131,8 +131,7 @@ class SpecialShareAchievement extends SpecialPage {
 		$userBetaEnabled = $betaConfigEnabled && BetaFeatures::isFeatureEnabled( $viewer,
 				Constants::PREF_KEY_ACHIEVEMENT_ENABLE );
 		if ( $viewer->isAnon() ) {
-			$data['text-suggestion'] = $this->msg( 'special-shareachievement-suggestion-sign-up',
-				$viewer->getName() )->parse();
+			$data['text-suggestion'] = $this->msg( 'special-shareachievement-suggestion-sign-up' )->parse();
 		} elseif ( $betaConfigEnabled && !$userBetaEnabled ) {
 			$data['text-suggestion'] = $this->msg( 'special-shareachievement-suggestion-beta',
 				$viewer->getName() )->parse();


### PR DESCRIPTION
The message special-shareachievement-suggestion-sign-up is shown only to anonymous users, so it cannot use a username or the GENDER keyword.